### PR TITLE
fix spelling

### DIFF
--- a/lib/Bio/Biblio.pm
+++ b/lib/Bio/Biblio.pm
@@ -164,7 +164,7 @@ lower-level object.
 
 This method can also be used for I<cloning> an existing object and
 changing or adding new attributes to it in the same time. This is,
-however, not particulary useful for the casual users of this module,
+however, not particularly useful for the casual users of this module,
 because the query methods (see L<Bio::DB::BiblioI>) themselves
 already return cloned objects with more refined query
 collections. Anyway this is how the cloning can be done:

--- a/lib/Bio/Biblio/IO.pm
+++ b/lib/Bio/Biblio/IO.pm
@@ -104,7 +104,7 @@ citations can be read by calling repeatedly method I<next_bibref>:
 However, this may imply that all citations were already read into the
 memory. If you expect a huge amount of citations to be read, you may
 choose a I<callback> option. Your subroutine is specified in the
-C<new()> method and is called everytime a new citation is available
+C<new()> method and is called every time a new citation is available
 (see an example above in SYNOPSIS).
 
 The citations returned by I<next_bibref> or given to your callback

--- a/lib/Bio/DB/BiblioI.pm
+++ b/lib/Bio/DB/BiblioI.pm
@@ -315,7 +315,7 @@ sub destroy { shift->throw_not_implemented; }
            of a controlled vocabulary
  Args    : none
 
-The controlled vocabularies allow to introspect bibliographic
+The controlled vocabularies allow one to introspect bibliographic
 repositories and to find what citation resource types (such as journal
 and book articles, patents or technical reports) are provided by the
 repository, what attributes they have, eventually what attribute


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Bio-Biblio.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libbio-biblio-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
